### PR TITLE
Cambios para proveedor en productos, nombre campo

### DIFF
--- a/apis/Producto.py
+++ b/apis/Producto.py
@@ -267,10 +267,7 @@ async def actualizar_producto(
             ),
             "id_proveedor": str(producto_actualizado.id_proveedor),
             "proveedor": (
-                {
-                    "nombre": f"{producto_actualizado.proveedor.primer_nombre} "
-                    f"{producto_actualizado.proveedor.primer_apellido}"
-                }
+                {"id_proveedor": f"{producto_actualizado.proveedor.primer_nombre} "}
                 if producto_actualizado.proveedor
                 else None
             ),


### PR DESCRIPTION
Ya se pueden actualizar los proveedores en producto, lo que pasaba era que el campo tenía el nombre que no era. Cuando puedas lo apruebas porfi, gracias